### PR TITLE
修复注释符号

### DIFF
--- a/_includes/setup/path-mac-linux.md
+++ b/_includes/setup/path-mac-linux.md
@@ -12,8 +12,8 @@
 
 
 ```commandline
-export PUB_HOSTED_URL=https://pub.flutter-io.cn //国内用户需要设置
-export FLUTTER_STORAGE_BASE_URL=https://storage.flutter-io.cn //国内用户需要设置
+export PUB_HOSTED_URL=https://pub.flutter-io.cn #国内用户需要设置
+export FLUTTER_STORAGE_BASE_URL=https://storage.flutter-io.cn #国内用户需要设置
 export PATH=PATH_TO_FLUTTER_GIT_DIRECTORY/flutter/bin:$PATH
 ```
 


### PR DESCRIPTION
“//”在.bash_profile文件中并非注释，直接复制进去导致环境变量设置不生效，修改为“#”