### PR TITLE
更新国际化文档代码语法错误

### DIFF
--- a/tutorials/international/index.md
+++ b/tutorials/international/index.md
@@ -186,7 +186,7 @@ class DemoLocalizations {
   static Future<DemoLocalizations> load(Locale locale) {
     final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
-    return initializeMessages(localeName).then((Null _) {
+    return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
       return new DemoLocalizations();
     });


### PR DESCRIPTION
英文官网此处代码没有Null，实际过程中有Null 会报错。

static Future<DemoLocalizations> load(Locale locale) {
    final String name = locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
    final String localeName = Intl.canonicalizedLocale(name);
    return initializeMessages(localeName).then((**Null** _) {    //   需要去掉这个Null
      return DemoLocalizations(localeName);
    });
  }